### PR TITLE
Fix typo in Home.vue

### DIFF
--- a/docs/.vuepress/components/Home.vue
+++ b/docs/.vuepress/components/Home.vue
@@ -24,7 +24,7 @@
         .features__item__text
           .features__item__text__h2 use
           .features__item__text__h1 Guides
-          .features__item__text__p Follow guides to using polular Ethereum tools with Evmos.
+          .features__item__text__p Follow guides to using popular Ethereum tools with Evmos.
     .sections__wrapper
       .h2 Explore Evmos
       .p__alt Get familiar with Evmos and explore its main concepts.


### PR DESCRIPTION
No issue raised.

## Description

Polular changed to popular in Home.vue

______

For contributor use:

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#pr-targeting))
Below not applicable to minor typo fix.
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Code follows the [module structure standards](https://github.com/cosmos/cosmos-sdk/blob/master/docs/building-modules/structure.md).
- [ ] Wrote unit and integration [tests](https://github.com/cosmos/cosmos-sdk/blob/master/CONTRIBUTING.md#testing)
- [ ] Updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)
- [ ] Added  relevant `godoc` [comments](https://blog.golang.org/godoc-documenting-go-code).
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer

______

For admin use:

- [ ] Added appropriate labels to PR (ex. `WIP`, `R4R`, `docs`, etc)
- [ ] Reviewers assigned
- [ ] Squashed all commits, uses message "Merge pull request #XYZ: [title]" ([coding standards](https://github.com/tendermint/coding/blob/master/README.md#merging-a-pr))
