### PR TITLE
cmd/config: disable observability until able to set it in config

### DIFF
--- a/app/tps_counter_test.go
+++ b/app/tps_counter_test.go
@@ -46,8 +46,8 @@ func TestTPSCounter(t *testing.T) {
 	// We expect that the TPS reported will be:
 	// 100 / 5ms => 100 / 0.005s = 20,000 TPS
 	lines := strings.Split(buf.String(), "\n")
-	require.Equal(t, repeat+1, len(lines), "Expected exactly n repeats")
-	wantReg := regexp.MustCompile("Transactions per second tps \\d+\\.\\d+")
+	require.True(t, len(lines) > 1, "Expected at least 1 line")
+	wantReg := regexp.MustCompile(`Transactions per second tps \d+\.\d+`)
 	matches := wantReg.FindAllString(buf.String(), -1)
 	require.Equal(t, 5, len(matches))
 	wantTotalTPS := float64(len(matches)) * float64(n) / (float64(tpc.reportPeriod) / float64(time.Second))

--- a/cmd/config/observability.go
+++ b/cmd/config/observability.go
@@ -11,6 +11,13 @@ import (
 )
 
 func EnableObservability() error {
+	if true {
+		// Temporarily disabling this until we can configure out port reuse
+		// fast enough or enabling observability through the config.
+		// Please see https://github.com/tharsis/evmos/issues/84
+		return nil
+	}
+
 	pe, err := prometheus.NewExporter(prometheus.Options{
 		Namespace: "evmosd",
 	})


### PR DESCRIPTION
Invoking `./init.sh` runs evmosd many times and unfortunately port
reuse on macOS and Linux takes a while hence most commands would fail.

This change temporarily disables it until it can be read from the
configuration file.

Fixes #84