### PR TITLE
Bug(Intrarelayer): Add validation of "intrarelayer/" prefix for Coin denominations in ConvertCoin

### DIFF
--- a/x/intrarelayer/types/msg.go
+++ b/x/intrarelayer/types/msg.go
@@ -35,9 +35,12 @@ func (msg MsgConvertCoin) Type() string { return TypeMsgConvertCoin }
 
 // ValidateBasic runs stateless checks on the message
 func (msg MsgConvertCoin) ValidateBasic() error {
-	if err := ibctransfertypes.ValidateIBCDenom(msg.Coin.Denom); err != nil {
-		return err
+	if err := ValidateIntrarelayerDenom(msg.Coin.Denom); err != nil {
+		if err := ibctransfertypes.ValidateIBCDenom(msg.Coin.Denom); err != nil {
+			return err
+		}
 	}
+
 	if !msg.Coin.Amount.IsPositive() {
 		return sdkerrors.Wrapf(sdkerrors.ErrInvalidCoins, "cannot mint a non-positive amount")
 	}

--- a/x/intrarelayer/types/msg_test.go
+++ b/x/intrarelayer/types/msg_test.go
@@ -113,7 +113,7 @@ func (suite *MsgsTestSuite) TestMsgConvertCoin() {
 		},
 		{
 			"msg convert coin - pass with `intrarelayer/` denom",
-			sdk.NewCoin("intrarelayer/coin", sdk.NewInt(100)),
+			sdk.NewCoin("intrarelayer/0xdac17f958d2ee523a2206206994597c13d831ec7", sdk.NewInt(100)),
 			tests.GenerateAddress().String(),
 			sdk.AccAddress(tests.GenerateAddress().Bytes()).String(),
 			true,

--- a/x/intrarelayer/types/msg_test.go
+++ b/x/intrarelayer/types/msg_test.go
@@ -83,7 +83,7 @@ func (suite *MsgsTestSuite) TestMsgConvertCoin() {
 		{
 			"negative coin amount",
 			sdk.Coin{
-				Denom:  "test",
+				Denom:  "coin",
 				Amount: sdk.NewInt(-100),
 			},
 			"0x0000",
@@ -92,21 +92,35 @@ func (suite *MsgsTestSuite) TestMsgConvertCoin() {
 		},
 		{
 			"msg convert coin - invalid sender",
-			sdk.NewCoin("test", sdk.NewInt(100)),
+			sdk.NewCoin("coin", sdk.NewInt(100)),
 			tests.GenerateAddress().String(),
 			"evmosinvalid",
 			false,
 		},
 		{
 			"msg convert coin - invalid receiver",
-			sdk.NewCoin("test", sdk.NewInt(100)),
+			sdk.NewCoin("coin", sdk.NewInt(100)),
 			"0x0000",
 			sdk.AccAddress(tests.GenerateAddress().Bytes()).String(),
 			false,
 		},
 		{
 			"msg convert coin - pass",
-			sdk.NewCoin("test", sdk.NewInt(100)),
+			sdk.NewCoin("coin", sdk.NewInt(100)),
+			tests.GenerateAddress().String(),
+			sdk.AccAddress(tests.GenerateAddress().Bytes()).String(),
+			true,
+		},
+		{
+			"msg convert coin - pass with `intrarelayer/` denom",
+			sdk.NewCoin("intrarelayer/coin", sdk.NewInt(100)),
+			tests.GenerateAddress().String(),
+			sdk.AccAddress(tests.GenerateAddress().Bytes()).String(),
+			true,
+		},
+		{
+			"msg convert coin - pass with `ibc/{hash}` denom",
+			sdk.NewCoin("ibc/7F1D3FCF4AE79E1554D670D1AD949A9BA4E4A3C76C63093E17E446A46061A7A2", sdk.NewInt(100)),
 			tests.GenerateAddress().String(),
 			sdk.AccAddress(tests.GenerateAddress().Bytes()).String(),
 			true,

--- a/x/intrarelayer/types/proposal.go
+++ b/x/intrarelayer/types/proposal.go
@@ -116,7 +116,7 @@ func ValidateIntrarelayerDenom(denom string) error {
 		return fmt.Errorf("invalid denom. %s denomination should be prefixed with the format 'intrarelayer/", denom)
 	}
 
-	return nil
+	return ethermint.ValidateAddress(denomSplit[1])
 }
 
 // NewRegisterERC20Proposal returns new instance of RegisterERC20Proposal

--- a/x/intrarelayer/types/proposal.go
+++ b/x/intrarelayer/types/proposal.go
@@ -107,6 +107,18 @@ func validateIBC(metadata banktypes.Metadata) error {
 	return nil
 }
 
+// ValidateIntrarelayerDenom checks if a denom is a valid intrarelayer/
+// denomination
+func ValidateIntrarelayerDenom(denom string) error {
+	denomSplit := strings.SplitN(denom, "/", 2)
+
+	if len(denomSplit) != 2 || denomSplit[0] != ModuleName {
+		return fmt.Errorf("invalid denom. %s denomination should be prefixed with the format 'intrarelayer/", denom)
+	}
+
+	return nil
+}
+
 // NewRegisterERC20Proposal returns new instance of RegisterERC20Proposal
 func NewRegisterERC20Proposal(title, description, erc20Addr string) govtypes.Content {
 	return &RegisterERC20Proposal{

--- a/x/intrarelayer/types/proposal_test.go
+++ b/x/intrarelayer/types/proposal_test.go
@@ -32,6 +32,44 @@ func (suite *ProposalTestSuite) TestKeysTypes() {
 	suite.Require().Equal("ToggleTokenRelay", (&ToggleTokenRelayProposal{}).ProposalType())
 }
 
+func (suite *ProposalTestSuite) TestValidateIntrarelayerDenom() {
+	testCases := []struct {
+		name    string
+		denom   string
+		expPass bool
+	}{
+		{
+			"- instead of /",
+			"intrarelayer-coin",
+			false,
+		},
+		{
+			"without /",
+			"intrarelayerCoin",
+			false,
+		},
+		{
+			"// instead of /",
+			"intrarelayer//coin",
+			true,
+		},
+		{
+			"multiple /",
+			"intrarelayer/coin/test",
+			true,
+		},
+	}
+	for _, tc := range testCases {
+		err := ValidateIntrarelayerDenom(tc.denom)
+
+		if tc.expPass {
+			suite.Require().Nil(err, tc.name)
+		} else {
+			suite.Require().Error(err, tc.name)
+		}
+	}
+}
+
 func (suite *ProposalTestSuite) TestRegisterERC20Proposal() {
 	testCases := []struct {
 		msg         string

--- a/x/intrarelayer/types/proposal_test.go
+++ b/x/intrarelayer/types/proposal_test.go
@@ -40,7 +40,7 @@ func (suite *ProposalTestSuite) TestValidateIntrarelayerDenom() {
 	}{
 		{
 			"- instead of /",
-			"intrarelayer-coin",
+			"intrarelayer-0xdac17f958d2ee523a2206206994597c13d831ec7",
 			false,
 		},
 		{
@@ -50,12 +50,17 @@ func (suite *ProposalTestSuite) TestValidateIntrarelayerDenom() {
 		},
 		{
 			"// instead of /",
-			"intrarelayer//coin",
-			true,
+			"intrarelayer//0xdac17f958d2ee523a2206206994597c13d831ec7",
+			false,
 		},
 		{
 			"multiple /",
-			"intrarelayer/coin/test",
+			"intrarelayer/0xdac17f958d2ee523a2206206994597c13d831ec7/test",
+			false,
+		},
+		{
+			"pass",
+			"intrarelayer/0xdac17f958d2ee523a2206206994597c13d831ec7",
 			true,
 		},
 	}


### PR DESCRIPTION
Closes: https://linear.app/tharsis/issue/ENG-315/intrarelayer-prefix-breaks-coin-conversion

### Description

With `RegisterERC20` the representative native Cosmos Coin has a `intrarelayer/ prefix` . This PR fixes the  validation during `ConvertCoin`.