### PR TITLE
app: fix typo in calculation of failed transactions in TPS value

### DIFF
--- a/app/tps_counter.go
+++ b/app/tps_counter.go
@@ -76,7 +76,7 @@ func (tpc *tpsCounter) start(ctx context.Context) error {
 			} else {
 				panic(err)
 			}
-			nFailed, err := tpc.recordValue(ctx, latestNSuccessful, lastNFailed, statusFailure)
+			nFailed, err := tpc.recordValue(ctx, latestNFailed, lastNFailed, statusFailure)
 			if err == nil {
 				nTxn += nFailed
 			} else {


### PR DESCRIPTION
Noticed while I was auditing through evmosd code that inside
the code that records TPS, that we have a typo in the calculation
of nFailed, that instead used latestNSuccessful, of which if enough
time is spent and the successful transactions have grown, while
the number of failed transactions stays still, this can cause
wrong TPS values to be reported.