### PR TITLE
bug(vesting): fail delegation if account is locked

### DIFF
--- a/app/ante/vesting.go
+++ b/app/ante/vesting.go
@@ -119,7 +119,7 @@ func (vdd VestingDelegationDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, sim
 			islocked := clawbackAccount.HasLockedCoins(ctx.BlockTime())
 			if islocked {
 				return ctx, sdkerrors.Wrapf(vestingtypes.ErrVestingLockup,
-					"cannot perform Ethereum tx with clawback vesting account, that has locked coins: %s", clawbackAccount.GetLockedOnly(ctx.BlockTime()),
+					"cannot delegate coins with clawback vesting account, that has locked coins: %s", clawbackAccount.GetLockedOnly(ctx.BlockTime()),
 				)
 			}
 

--- a/x/vesting/keeper/integration_test.go
+++ b/x/vesting/keeper/integration_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 		s.Require().True(vested.IsZero())
 	})
 
-	Context("before cliff", func() {
+	Context("before first vesting period", func() {
 		It("cannot delegate tokens", func() {
 			err := delegate(clawbackAccount, 100)
 			Expect(err).ToNot(BeNil())
@@ -119,7 +119,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 		})
 	})
 
-	Context("after cliff and before lockup", func() {
+	Context("after first vesting period and before lockup", func() {
 		BeforeEach(func() {
 			// Surpass cliff but not lockup duration
 			cliffDuration := time.Duration(cliffLength)
@@ -132,9 +132,9 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 			s.Require().Equal(expVested, vested)
 		})
 
-		It("can delegate vested tokens", func() {
+		It("cannot delegate vested tokens", func() {
 			err := delegate(clawbackAccount, 1)
-			Expect(err).To(BeNil())
+			Expect(err).ToNot(BeNil())
 		})
 
 		It("cannot transfer vested tokens", func() {
@@ -153,7 +153,7 @@ var _ = Describe("Clawback Vesting Accounts", Ordered, func() {
 		})
 	})
 
-	Context("after cliff and lockup", func() {
+	Context("after first vesting period and lockup", func() {
 		BeforeEach(func() {
 			// Surpass lockup duration
 			lockupDuration := time.Duration(lockupLength)

--- a/x/vesting/types/clawback_vesting_account.go
+++ b/x/vesting/types/clawback_vesting_account.go
@@ -227,9 +227,5 @@ func (va ClawbackVestingAccount) UpdateDelegation(
 // HasLockedCoins returns true if the blocktime has not passed all clawback
 // account's lockup periods
 func (va ClawbackVestingAccount) HasLockedCoins(blockTime time.Time) bool {
-	unlockingTime := va.StartTime
-	for _, lp := range va.LockupPeriods {
-		unlockingTime = unlockingTime.Add(time.Duration(lp.Length))
-	}
-	return blockTime.Before(unlockingTime)
+	return !va.GetLockedOnly(blockTime).IsZero()
 }


### PR DESCRIPTION
### Description

This PR updates the ante `VestingDelegationDecorator` to fail when a user tries to delegate vested or unvested tokens from an account that is still in lockup (has locked coins).