### PR TITLE
spec(bug): fix module table of content links (ENG-526)

### DIFF
--- a/x/claims/spec/README.md
+++ b/x/claims/spec/README.md
@@ -29,8 +29,7 @@ Furthermore, these claimable assets 'expire' if not claimed. Users have two mont
 1. **[Concepts](01_concepts.md)**
 2. **[State](02_state.md)**
 3. **[State Transitions](03_state_transitions.md)**
-4. **[Transactions](04_transactions.md)**
-5. **[Hooks](05_hooks.md)**
-6. **[Events](06_events.md)**
-7. **[Parameters](07_params.md)**
-8. **[Clients](08_clients.md)**
+4. **[Hooks](04_hooks.md)**
+5. **[Events](05_events.md)**
+6. **[Parameters](06_parameters.md)**
+7. **[Clients](07_clients.md)**

--- a/x/erc20/spec/README.md
+++ b/x/erc20/spec/README.md
@@ -31,5 +31,5 @@ With the `x/erc20` users on Evmos can
 4. **[Transactions](04_transactions.md)**
 5. **[Hooks](05_hooks.md)**
 6. **[Events](06_events.md)**
-7. **[Parameters](07_params.md)**
+7. **[Parameters](07_parameters.md)**
 8. **[Clients](08_clients.md)**

--- a/x/incentives/spec/README.md
+++ b/x/incentives/spec/README.md
@@ -25,5 +25,5 @@ Users participate in incentives by submitting transactions to an incentivized co
 4. **[Transactions](04_transactions.md)**
 5. **[Hooks](05_hooks.md)**
 6. **[Events](06_events.md)**
-7. **[Parameters](07_params.md)**
+7. **[Parameters](07_parameters.md)**
 8. **[Clients](08_clients.md)**

--- a/x/inflation/spec/README.md
+++ b/x/inflation/spec/README.md
@@ -31,5 +31,5 @@ account  to provide supply for usage incentives and 3) the community pool
 2. **[State](02_state.md)**
 3. **[Hooks](03_hooks.md)**
 4. **[Events](04_events.md)**
-5. **[Parameters](05_params.md)**
+5. **[Parameters](05_parameters.md)**
 6. **[Clients](06_clients.md)**


### PR DESCRIPTION
### Description

This PR fixes links in the [specs](https://evmos.dev/).

Closes https://linear.app/tharsis/issue/ENG-526/link-to-parameters-broken-in-inflation-spec-content-overview