### PR TITLE
fix: return nil on erc20 evm hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 # Changelog
 
+## Unreleased
+
+### Bug Fixes
+
+- (erc20) [\#336](https://github.com/tharsis/evmos/pull/336) Return `nil` for disabled ERC20 module or ERC20 EVM hook.
+
 ## [v1.1.0] - 2022-03-02
 
 ### Bug Fixes


### PR DESCRIPTION

```
11:06AM ERR tx post processing failed error="EVM hook keeper.Hooks failed: EVM Hook is currently disabled: internal ethereum token mapping error" module=evm
```