### PR TITLE
release: v2.0.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+## [v2.0.1] - 2022-03-06
+
+### Bug Fixes
+
+- (upgrade) [#\363](https://github.com/tharsis/evmos/pull/363) Don't use `GetParams` for upgrades.
+
 ## [v2.0.0] - 2022-03-06
 
 ### State Machine Breaking

--- a/x/claims/migrations/v2/migration.go
+++ b/x/claims/migrations/v2/migration.go
@@ -14,10 +14,15 @@ type ClaimsKeeper interface {
 }
 
 func UpdateParams(ctx sdk.Context, k ClaimsKeeper) error {
-	claimsParams := k.GetParams(ctx)
-	claimsParams.DurationUntilDecay += time.Hour * 24 * 14 // add 2 weeks
-	claimsParams.AuthorizedChannels = types.DefaultAuthorizedChannels
-	claimsParams.EVMChannels = types.DefaultEVMChannels
+	claimsParams := types.Params{
+		EnableClaims:       true,
+		AirdropStartTime:   time.Date(2022, time.March, 3, 18, 0, 0, 0, time.UTC),
+		DurationUntilDecay: (2592000 * time.Second) + (time.Hour * 24 * 14), // add 2 weeks
+		DurationOfDecay:    5184000 * time.Second,
+		ClaimsDenom:        "aevmos",
+		AuthorizedChannels: types.DefaultAuthorizedChannels,
+		EVMChannels:        types.DefaultEVMChannels,
+	}
 	k.SetParams(ctx, claimsParams)
 	return nil
 }


### PR DESCRIPTION
- release: bump Evmos version to v2 (#351)
- app: upgrade handler for v2 (#352)
- Merge pull request from GHSA-5jgq-x857-p8xw
- fix: don't use GetParams (#363)
