### PR TITLE
ENG-109 - impr(claims): remove claims merge/migrate cases where sender already completed an action as they are never reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,7 +63,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (inflation) [\#369](https://github.com/tharsis/evmos/pull/369) Add `enableInflation` parameter.
 - (claims) [\#432](https://github.com/tharsis/evmos/pull/432) Add IBC trigger amount to claims merge/migrate IBC callbacks.
 - (claims) [\#442](https://github.com/tharsis/evmos/pull/443) Remove claims merge/migrate cases where sender already completed an action as they are never reached
--
+
 ## [v2.0.1] - 2022-03-06
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (inflation) [\#383](https://github.com/tharsis/evmos/pull/383) Add gRPC endpoints for inflation rate and total supply
 - (inflation) [\#369](https://github.com/tharsis/evmos/pull/369) Add `enableInflation` parameter.
 - (claims) [\#432](https://github.com/tharsis/evmos/pull/432) Add IBC trigger amount to claims merge/migrate IBC callbacks.
-
+- (claims) [\#442](https://github.com/tharsis/evmos/pull/443) Remove claims merge/migrate cases where sender already completed an action as they are never reached
+-
 ## [v2.0.1] - 2022-03-06
 
 ### Bug Fixes

--- a/init.sh
+++ b/init.sh
@@ -49,7 +49,7 @@ cat $HOME/.evmosd/config/genesis.json | jq -r --arg node_address "$node_address"
 
 # Set claims decay
 cat $HOME/.evmosd/config/genesis.json | jq -r --arg current_date "$current_date" '.app_state["claims"]["params"]["duration_of_decay"]="1000000s"' > $HOME/.evmosd/config/tmp_genesis.json && mv $HOME/.evmosd/config/tmp_genesis.json $HOME/.evmosd/config/genesis.json
-cat $HOME/.evmosd/config/genesis.json | jq -r --arg current_date "$current_date" '.app_state["claims"]["params"]["duration_until_decay"]="100000s"' > $HOME/.evmosd/config/tmp_genesis.json && mv $HOME/.evmosd/config/tmp_genesis.json $HOME/.evmosd/config/genesis.json
+cat $HOME/.evmosd/config/genesis.json | jq -r --arg current_date "$current_date" '.app_state["claims"]["params"]["duration_until_decay"]="300s"' > $HOME/.evmosd/config/tmp_genesis.json && mv $HOME/.evmosd/config/tmp_genesis.json $HOME/.evmosd/config/genesis.json
 
 # Claim module account:
 # 0xA61808Fe40fEb8B3433778BBC2ecECCAA47c8c47 || evmos15cvq3ljql6utxseh0zau9m8ve2j8erz89m5wkz

--- a/x/claims/keeper/claim.go
+++ b/x/claims/keeper/claim.go
@@ -103,8 +103,8 @@ func (k Keeper) MergeClaimsRecords(
 		// Safety check: the sender record cannot have any claimed actions, as
 		//  - the sender is not an evmos address and can't claim vote, delegation or evm actions
 		//  - the first attempt to perform an ibc callback from the senders account will merge/migrate the entire claims record
-		if senderCompleted := senderClaimsRecord.HasClaimedAction(action); senderCompleted {
-			return types.ClaimsRecord{}, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "non-evmos sender must not have claimed action: %v", action)
+		if senderClaimsRecord.HasClaimedAction(action) {
+			return types.ClaimsRecord{}, sdkerrors.Wrapf(sdkerrors.ErrNotSupported, "non-evmos sender must not have claimed action: %v", action)
 		}
 
 		recipientCompleted := recipientClaimsRecord.HasClaimedAction(action)

--- a/x/claims/keeper/claim.go
+++ b/x/claims/keeper/claim.go
@@ -99,30 +99,23 @@ func (k Keeper) MergeClaimsRecords(
 	// the recipient or sender has completed an action but the other hasn't
 	actions := []types.Action{types.ActionVote, types.ActionDelegate, types.ActionEVM, types.ActionIBCTransfer}
 	for _, action := range actions {
-		senderCompleted := senderClaimsRecord.HasClaimedAction(action)
+
+		// Safety check: the sender record cannot have any claimed actions, as
+		//  - the sender is not an evmos address and can't claim vote, delegation or evm actions
+		//  - the first attempt to perform an ibc callback from the senders account will merge/migrate the entire claims record
+		if senderCompleted := senderClaimsRecord.HasClaimedAction(action); senderCompleted {
+			return types.ClaimsRecord{}, sdkerrors.Wrapf(sdkerrors.ErrUnknownRequest, "non-evmos sender must not have claimed action: %v", action)
+		}
+
 		recipientCompleted := recipientClaimsRecord.HasClaimedAction(action)
 
-		switch {
-		case senderCompleted && recipientCompleted:
-			// Both sender and recipient completed the action.
-			// Only mark the action as completed
-			mergedRecord.MarkClaimed(action)
-
-		case recipientCompleted && !senderCompleted:
+		if recipientCompleted {
 			// claim action for sender since the recipient completed it
 			amt, remainder := k.GetClaimableAmountForAction(ctx, senderClaimsRecord, action, params)
 			claimedAmt = claimedAmt.Add(amt)
 			remainderAmt = remainderAmt.Add(remainder)
 			mergedRecord.MarkClaimed(action)
-
-		case !recipientCompleted && senderCompleted:
-			// claim action for recipient since the sender completed it
-			amt, remainder := k.GetClaimableAmountForAction(ctx, recipientClaimsRecord, action, params)
-			claimedAmt = claimedAmt.Add(amt)
-			remainderAmt = remainderAmt.Add(remainder)
-			mergedRecord.MarkClaimed(action)
-
-		case !senderCompleted && !recipientCompleted:
+		} else {
 			// Neither sender or recipient completed the action.
 			if action != types.ActionIBCTransfer {
 				// No-op if the action is not IBC transfer

--- a/x/claims/keeper/ibc_callbacks_test.go
+++ b/x/claims/keeper/ibc_callbacks_test.go
@@ -124,8 +124,8 @@ func (suite *IBCTestingSuite) TestOnReceiveClaim() {
 				amt := sdk.NewInt(claimableAmount)
 				coins := sdk.NewCoins(sdk.NewCoin("aevmos", amt.Add(amt.QuoRaw(2))))
 
-				suite.chainB.App.(*app.Evmos).ClaimsKeeper.SetClaimsRecord(suite.chainB.GetContext(), senderAddr, types.ClaimsRecord{InitialClaimableAmount: amt, ActionsCompleted: []bool{false, false, true, false}})
-				suite.chainB.App.(*app.Evmos).ClaimsKeeper.SetClaimsRecord(suite.chainB.GetContext(), receiverAddr, types.ClaimsRecord{InitialClaimableAmount: amt, ActionsCompleted: []bool{false, true, false, false}})
+				suite.chainB.App.(*app.Evmos).ClaimsKeeper.SetClaimsRecord(suite.chainB.GetContext(), senderAddr, types.ClaimsRecord{InitialClaimableAmount: amt, ActionsCompleted: []bool{false, false, false, false}})
+				suite.chainB.App.(*app.Evmos).ClaimsKeeper.SetClaimsRecord(suite.chainB.GetContext(), receiverAddr, types.ClaimsRecord{InitialClaimableAmount: amt, ActionsCompleted: []bool{false, true, true, false}})
 
 				// update the escrowed account balance to maintain the invariant
 				err := testutil.FundModuleAccount(suite.chainB.App.(*app.Evmos).BankKeeper, suite.chainB.GetContext(), types.ModuleName, coins)


### PR DESCRIPTION
### Description

This PR simplifies the merge/migrate logic for claiming records with the  IBC `OnRecvCallback`.

Note: Please confirm that it should not be possible for non-evmos claims records to exist, which have actions claimed. The rationale behind this is that non-evmos addresses with claims records
- cannot claim VOTE, DELEGATE or EVM_ACTIONS
- always have their claims record merged/migrated on the first attempt of performing the IBC callback
