### PR TITLE
app: add ethermint.EncodingTxDecoder fuzz test

### DIFF
--- a/app/fuzz_test.go
+++ b/app/fuzz_test.go
@@ -1,0 +1,23 @@
+package app
+
+import (
+	"testing"
+
+	"github.com/tharsis/ethermint/encoding"
+)
+
+func FuzzEncodingTxDecoder(f *testing.F) {
+	f.Skip("TODO (@fedekunze, @odeke-em): Add the corpus")
+
+	txConfig := encoding.MakeConfig(ModuleBasics).TxConfig
+
+	// TODO: Add the corpus.
+	f.Add([]byte(""))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		tx, err := txConfig.TxDecoder()(data)
+		if tx == nil && err == nil {
+			t.Fatal("nil tx yet nil err")
+		}
+	})
+}


### PR DESCRIPTION
Writes the first fuzz test to test out
ethermint/encoding.MakeConfig.TxConfig.TxDecoder()

Used a TODO so that @fedekunze can add the corpus
to guide the fuzzer.