### PR TITLE
Revert "imp: only delete records at the end of the claims period"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,6 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### State Machine Breaking
 
-- [\#430](https://github.com/tharsis/evmos/pull/430) Exclusively delete claims records at the end of the claims period.
 - [\#342](https://github.com/tharsis/evmos/pull/342) Implement IBC middleware to recover stuck funds
 
 ### API Breaking

--- a/x/claims/keeper/abci_test.go
+++ b/x/claims/keeper/abci_test.go
@@ -9,7 +9,6 @@ import (
 	distrtypes "github.com/cosmos/cosmos-sdk/x/distribution/types"
 	"github.com/tharsis/ethermint/tests"
 
-	"github.com/tharsis/evmos/v3/testutil"
 	"github.com/tharsis/evmos/v3/x/claims/types"
 	inflationtypes "github.com/tharsis/evmos/v3/x/inflation/types"
 	vestingtypes "github.com/tharsis/evmos/v3/x/vesting/types"
@@ -61,15 +60,13 @@ func (suite *KeeperTestSuite) TestEndBlock() {
 
 func (suite *KeeperTestSuite) TestClawbackEmptyAccounts() {
 	addr := sdk.AccAddress(tests.GenerateAddress().Bytes())
-	addr2 := sdk.AccAddress(tests.GenerateAddress().Bytes())
-	addr3 := sdk.AccAddress(tests.GenerateAddress().Bytes())
 
 	var amount int64 = 10000
 
 	testCases := []struct {
-		name       string
-		expBalance int64
-		malleate   func()
+		name     string
+		funds    int64
+		malleate func()
 	}{
 		{
 			"no claims records",
@@ -125,7 +122,9 @@ func (suite *KeeperTestSuite) TestClawbackEmptyAccounts() {
 				suite.app.AccountKeeper.SetAccount(suite.ctx, authtypes.NewBaseAccount(addr, nil, 0, 0))
 
 				coins := sdk.NewCoins(sdk.NewCoin("aevmos", sdk.NewInt(amount)))
-				err := testutil.FundAccount(suite.app.BankKeeper, suite.ctx, addr, coins)
+				err := suite.app.BankKeeper.MintCoins(suite.ctx, inflationtypes.ModuleName, coins)
+				suite.Require().NoError(err)
+				err = suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, inflationtypes.ModuleName, addr, coins)
 				suite.Require().NoError(err)
 				suite.app.ClaimsKeeper.SetClaimsRecord(suite.ctx, addr, types.ClaimsRecord{})
 			},
@@ -137,30 +136,11 @@ func (suite *KeeperTestSuite) TestClawbackEmptyAccounts() {
 				suite.app.AccountKeeper.SetAccount(suite.ctx, authtypes.NewBaseAccount(addr, nil, 0, 0))
 
 				coins := sdk.NewCoins(sdk.NewCoin("testcoin", sdk.NewInt(amount)))
-				err := testutil.FundAccount(suite.app.BankKeeper, suite.ctx, addr, coins)
+				err := suite.app.BankKeeper.MintCoins(suite.ctx, inflationtypes.ModuleName, coins)
+				suite.Require().NoError(err)
+				err = suite.app.BankKeeper.SendCoinsFromModuleToAccount(suite.ctx, inflationtypes.ModuleName, addr, coins)
 				suite.Require().NoError(err)
 				suite.app.ClaimsKeeper.SetClaimsRecord(suite.ctx, addr, types.ClaimsRecord{})
-			},
-		},
-		{
-			"multiple accounts, all clawed back ",
-			amount * 3,
-			func() {
-				suite.app.AccountKeeper.SetAccount(suite.ctx, authtypes.NewBaseAccount(addr, nil, 0, 0))
-				suite.app.AccountKeeper.SetAccount(suite.ctx, authtypes.NewBaseAccount(addr2, nil, 0, 0))
-				suite.app.AccountKeeper.SetAccount(suite.ctx, authtypes.NewBaseAccount(addr3, nil, 0, 0))
-
-				coins := sdk.NewCoins(sdk.NewCoin("aevmos", sdk.NewInt(amount)))
-				err := testutil.FundAccount(suite.app.BankKeeper, suite.ctx, addr, coins)
-				suite.Require().NoError(err)
-				err = testutil.FundAccount(suite.app.BankKeeper, suite.ctx, addr2, coins)
-				suite.Require().NoError(err)
-				err = testutil.FundAccount(suite.app.BankKeeper, suite.ctx, addr2, coins)
-				suite.Require().NoError(err)
-
-				suite.app.ClaimsKeeper.SetClaimsRecord(suite.ctx, addr, types.ClaimsRecord{})
-				suite.app.ClaimsKeeper.SetClaimsRecord(suite.ctx, addr2, types.ClaimsRecord{})
-				suite.app.ClaimsKeeper.SetClaimsRecord(suite.ctx, addr3, types.ClaimsRecord{})
 			},
 		},
 	}
@@ -174,11 +154,7 @@ func (suite *KeeperTestSuite) TestClawbackEmptyAccounts() {
 
 			moduleAcc := suite.app.AccountKeeper.GetModuleAccount(suite.ctx, distrtypes.ModuleName)
 			balance := suite.app.BankKeeper.GetBalance(suite.ctx, moduleAcc.GetAddress(), "aevmos")
-			suite.Require().Equal(tc.expBalance, balance.Amount.Int64())
-
-			// test that all claims records are deleted
-			claimsRecords := suite.app.ClaimsKeeper.GetClaimsRecords(suite.ctx)
-			suite.Require().Len(claimsRecords, 0)
+			suite.Require().Equal(tc.funds, balance.Amount.Int64())
 		})
 	}
 }
@@ -202,7 +178,9 @@ func (suite *KeeperTestSuite) TestClawbackEscrowedTokensABCI() {
 			amount,
 			func() {
 				coins := sdk.NewCoins(sdk.NewCoin("aevmos", sdk.NewInt(amount)))
-				err := testutil.FundModuleAccount(suite.app.BankKeeper, suite.ctx, types.ModuleName, coins)
+				err := suite.app.BankKeeper.MintCoins(suite.ctx, inflationtypes.ModuleName, coins)
+				suite.Require().NoError(err)
+				err = suite.app.BankKeeper.SendCoinsFromModuleToModule(suite.ctx, inflationtypes.ModuleName, types.ModuleName, coins)
 				suite.Require().NoError(err)
 			},
 		},

--- a/x/claims/keeper/claim.go
+++ b/x/claims/keeper/claim.go
@@ -63,7 +63,11 @@ func (k Keeper) ClaimCoinsForAction(
 		),
 	})
 
-	k.SetClaimsRecord(ctx, addr, claimsRecord)
+	if claimsRecord.HasClaimedAll() {
+		k.DeleteClaimsRecord(ctx, addr)
+	} else {
+		k.SetClaimsRecord(ctx, addr, claimsRecord)
+	}
 
 	k.Logger(ctx).Info(
 		"claimed action",

--- a/x/claims/keeper/ibc_callbacks_test.go
+++ b/x/claims/keeper/ibc_callbacks_test.go
@@ -474,7 +474,7 @@ func (suite *KeeperTestSuite) TestReceive() {
 				suite.Require().True(resAck.Success())
 
 				// check that the record is merged to the recipient
-				suite.Require().True(suite.app.ClaimsKeeper.HasClaimsRecord(suite.ctx, sender))
+				suite.Require().False(suite.app.ClaimsKeeper.HasClaimsRecord(suite.ctx, sender))
 				suite.Require().True(suite.app.ClaimsKeeper.HasClaimsRecord(suite.ctx, receiver))
 			},
 		},
@@ -525,7 +525,7 @@ func (suite *KeeperTestSuite) TestReceive() {
 				suite.Require().True(resAck.Success())
 
 				// check that the record is migrated
-				suite.Require().True(suite.app.ClaimsKeeper.HasClaimsRecord(suite.ctx, sender))
+				suite.Require().False(suite.app.ClaimsKeeper.HasClaimsRecord(suite.ctx, sender))
 				suite.Require().True(suite.app.ClaimsKeeper.HasClaimsRecord(suite.ctx, receiver))
 			},
 		},

--- a/x/claims/spec/04_hooks.md
+++ b/x/claims/spec/04_hooks.md
@@ -90,7 +90,7 @@ The user receives an IBC transfer from a counterparty chain. If the transfer is 
 	return an error, unless the destination channel from a connection to a chain
 	is EVM-compatible or supports ethereum keys (eg: Cronos, Injective).
 6. Check if destination channel is authorized to perform the IBC claim. Without this authorization the claiming process is vulerable to attacks.
-7. Handle one of four cases by comparing sender and recipient addresses with each other and checking if either addresses have a claims record (i.e allocation) for the airdrop. To compare both addresses, the sender address's bech32 human readable prefix (HRP) is replaced with `evmos1`.
+7. Handle one of four cases by comparing sender and recipient addresses with each other and checking if either addresses have a claims record (i.e allocation) for the airdrop. To compare both addresses, the sender address's bech32 human readable prefix (HRP) is replaced with `evmos`.
    1. both sender and recipient are distinct and have a claims record -> merge sender's record with the recipient's record and claim actions that have been completed by one or the other
    2. only the sender has a claims record -> migrate the sender record to the recipient address and claim IBC action
    3. only the recipient has a claims record -> only claim IBC transfer action and transfer the claimable amount from the escrow account to the user balance

--- a/x/claims/spec/04_hooks.md
+++ b/x/claims/spec/04_hooks.md
@@ -20,7 +20,7 @@ The user votes on a Governance proposal using their Evmos account. Once the vote
     - claimable amount is greater than zero
 3. Transfer the claimable amount from the escrow account to the user balance
 4. Mark the `ActionVote` as completed on the claims record.
-5. Update the claims record.
+5. Update the claims record or delete it if all the actions have been claimed.
 
 ## Staking Hook - Delegate Action
 
@@ -36,7 +36,7 @@ The user delegates their EVMOS tokens to a validator. Once the tokens are staked
     - claimable amount is greater than zero
 3. Transfer the claimable amount from the escrow account to the user balance
 4. Mark the `ActionDelegate` as completed on the claims record.
-5. Update the claims record.
+5. Update the claims record or delete it if all the actions have been claimed.
 
 ## EVM Hook - EVM Action
 
@@ -52,7 +52,7 @@ The user deploys or interacts with a smart contract using their Evmos account or
     - claimable amount is greater than zero
 3. Transfer the claimable amount from the escrow account to the user balance
 4. Mark the `ActionEVM` as completed on the claims record.
-5. Update the claims record.
+5. Update the claims record or delete it if all the actions have been claimed.
 
 ## IBC Middleware - IBC Transfer Action
 
@@ -71,7 +71,7 @@ The user submits an IBC transfer to a recipient in the destination chain. Once t
     - claimable amount is grater than zero
 6. Transfer the claimable amount from the escrow account to the user balance
 7. Mark the `ActionIBC` as completed on the claims record.
-8. Update the claims record.
+8. Update the claims record or delete it if all the actions have been claimed.
 
 ### Receive
 
@@ -90,7 +90,7 @@ The user receives an IBC transfer from a counterparty chain. If the transfer is 
 	return an error, unless the destination channel from a connection to a chain
 	is EVM-compatible or supports ethereum keys (eg: Cronos, Injective).
 6. Check if destination channel is authorized to perform the IBC claim. Without this authorization the claiming process is vulerable to attacks.
-7. Handle one of four cases by comparing sender and recipient addresses with each other and checking if either addresses have a claims record (i.e allocation) for the airdrop. To compare both addresses, the sender address's bech32 human readable prefix (HRP) is replaced with `evmos`.
+7. Handle one of four cases by comparing sender and recipient addresses with each other and checking if either addresses have a claims record (i.e allocation) for the airdrop. To compare both addresses, the sender address's bech32 human readable prefix (HRP) is replaced with `evmos1`.
    1. both sender and recipient are distinct and have a claims record -> merge sender's record with the recipient's record and claim actions that have been completed by one or the other
    2. only the sender has a claims record -> migrate the sender record to the recipient address and claim IBC action
    3. only the recipient has a claims record -> only claim IBC transfer action and transfer the claimable amount from the escrow account to the user balance


### PR DESCRIPTION
Reverts tharsis/evmos#430

The initial PR was implemented in order to retain migrated claims records instead of immediately deleting them. This allowed for more meaningful responses to gPRC requests that queried migrated claims records. For the dashboard frontend implementation, however, this change introduces unnecessary complexities.
