### PR TITLE
impr(claims): Retain claims records when all actions have been completed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 - (vesting) [\#486](https://github.com/tharsis/evmos/pull/486) Refactor `x/vesting` types and tests.
+- (claims) [\#516](https://github.com/tharsis/evmos/pull/516) Retain claims records when all actions have been completed.
 
 ### Bug Fixes
 

--- a/x/claims/keeper/claim.go
+++ b/x/claims/keeper/claim.go
@@ -63,11 +63,7 @@ func (k Keeper) ClaimCoinsForAction(
 		),
 	})
 
-	if claimsRecord.HasClaimedAll() {
-		k.DeleteClaimsRecord(ctx, addr)
-	} else {
-		k.SetClaimsRecord(ctx, addr, claimsRecord)
-	}
+	k.SetClaimsRecord(ctx, addr, claimsRecord)
 
 	k.Logger(ctx).Info(
 		"claimed action",

--- a/x/claims/keeper/claim_test.go
+++ b/x/claims/keeper/claim_test.go
@@ -361,7 +361,7 @@ func (suite *KeeperTestSuite) TestClaimCoinsForAction() {
 			sdk.NewInt(50),
 			sdk.ZeroInt(),
 			false,
-			true,
+			false,
 		},
 	}
 

--- a/x/claims/keeper/claim_test.go
+++ b/x/claims/keeper/claim_test.go
@@ -340,7 +340,7 @@ func (suite *KeeperTestSuite) TestClaimCoinsForAction() {
 			false,
 		},
 		{
-			"success - claimed all actions",
+			"success - claimed all actions - with VOTE as last action",
 			func() {
 				coins := sdk.NewCoins(sdk.NewCoin(types.DefaultClaimsDenom, sdk.NewInt(50)))
 				err := testutil.FundModuleAccount(suite.app.BankKeeper, suite.ctx, types.ModuleName, coins)
@@ -351,6 +351,30 @@ func (suite *KeeperTestSuite) TestClaimCoinsForAction() {
 				ActionsCompleted:       []bool{false, true, true, true},
 			},
 			types.ActionVote,
+			types.Params{
+				EnableClaims:       true,
+				AirdropStartTime:   suite.ctx.BlockTime().Add(-time.Hour),
+				DurationUntilDecay: 2 * time.Hour,
+				DurationOfDecay:    time.Hour,
+				ClaimsDenom:        types.DefaultClaimsDenom,
+			},
+			sdk.NewInt(50),
+			sdk.ZeroInt(),
+			false,
+			false,
+		},
+		{
+			"success - claimed all actions - with IBC as last action",
+			func() {
+				coins := sdk.NewCoins(sdk.NewCoin(types.DefaultClaimsDenom, sdk.NewInt(50)))
+				err := testutil.FundModuleAccount(suite.app.BankKeeper, suite.ctx, types.ModuleName, coins)
+				suite.Require().NoError(err)
+			},
+			types.ClaimsRecord{
+				InitialClaimableAmount: sdk.NewInt(200),
+				ActionsCompleted:       []bool{true, true, true, false},
+			},
+			types.ActionIBCTransfer,
 			types.Params{
 				EnableClaims:       true,
 				AirdropStartTime:   suite.ctx.BlockTime().Add(-time.Hour),

--- a/x/claims/keeper/ibc_callbacks_test.go
+++ b/x/claims/keeper/ibc_callbacks_test.go
@@ -680,7 +680,7 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 	}
 }
 
-func (suite *KeeperTestSuite) TestAck() {
+func (suite *KeeperTestSuite) TestOnAcknowledgementPacket() {
 	disabledTimeoutTimestamp := uint64(0)
 	timeoutHeight = clienttypes.NewHeight(0, 100)
 	mockpacket := channeltypes.NewPacket(ibcgotesting.MockPacketData, 1, transfertypes.PortID, "channel-0", transfertypes.PortID, "channel-0", timeoutHeight, disabledTimeoutTimestamp)

--- a/x/claims/keeper/ibc_callbacks_test.go
+++ b/x/claims/keeper/ibc_callbacks_test.go
@@ -605,8 +605,14 @@ func (suite *KeeperTestSuite) TestOnRecvPacket() {
 			},
 		},
 		{
-			"case 3: claim - same Address with EVM channel, with claims record",
+			"case 3: claim - same Address with authrorized EVM channel, with claims record",
 			func() {
+				params := suite.app.ClaimsKeeper.GetParams(suite.ctx)
+				params.AuthorizedChannels = []string{
+					"channel-2", // Injective
+				}
+				suite.app.ClaimsKeeper.SetParams(suite.ctx, params)
+
 				transfer := transfertypes.NewFungibleTokenPacketData("aevmos", "100", secpAddrCosmos, secpAddrEvmos)
 				bz := transfertypes.ModuleCdc.MustMarshalJSON(&transfer)
 				packet := channeltypes.NewPacket(bz, 1, transfertypes.PortID, "channel-0", transfertypes.PortID, types.DefaultEVMChannels[0], timeoutHeight, 0)

--- a/x/claims/spec/04_hooks.md
+++ b/x/claims/spec/04_hooks.md
@@ -20,7 +20,7 @@ The user votes on a Governance proposal using their Evmos account. Once the vote
     - claimable amount is greater than zero
 3. Transfer the claimable amount from the escrow account to the user balance
 4. Mark the `ActionVote` as completed on the claims record.
-5. Update the claims record or delete it if all the actions have been claimed.
+5. Update the claims record and retain it, even if all the actions have been claimed.
 
 ## Staking Hook - Delegate Action
 
@@ -36,7 +36,7 @@ The user delegates their EVMOS tokens to a validator. Once the tokens are staked
     - claimable amount is greater than zero
 3. Transfer the claimable amount from the escrow account to the user balance
 4. Mark the `ActionDelegate` as completed on the claims record.
-5. Update the claims record or delete it if all the actions have been claimed.
+5. Update the claims record and retain it, even if all the actions have been claimed.
 
 ## EVM Hook - EVM Action
 
@@ -52,7 +52,7 @@ The user deploys or interacts with a smart contract using their Evmos account or
     - claimable amount is greater than zero
 3. Transfer the claimable amount from the escrow account to the user balance
 4. Mark the `ActionEVM` as completed on the claims record.
-5. Update the claims record or delete it if all the actions have been claimed.
+5. Update the claims record and retain it, even if all the actions have been claimed.
 
 ## IBC Middleware - IBC Transfer Action
 
@@ -71,7 +71,7 @@ The user submits an IBC transfer to a recipient in the destination chain. Once t
     - claimable amount is grater than zero
 6. Transfer the claimable amount from the escrow account to the user balance
 7. Mark the `ActionIBC` as completed on the claims record.
-8. Update the claims record or delete it if all the actions have been claimed.
+8. Update the claims record and retain it, even if all the actions have been claimed.
 
 ### Receive
 

--- a/x/claims/types/params.go
+++ b/x/claims/types/params.go
@@ -25,6 +25,7 @@ var (
 	DefaultAuthorizedChannels = []string{
 		"channel-0", // Osmosis
 		"channel-3", // Cosmos Hub
+		"channel-2", // Injective
 	}
 	DefaultEVMChannels = []string{
 		"channel-2", // Injective

--- a/x/claims/types/params.go
+++ b/x/claims/types/params.go
@@ -25,7 +25,6 @@ var (
 	DefaultAuthorizedChannels = []string{
 		"channel-0", // Osmosis
 		"channel-3", // Cosmos Hub
-		"channel-2", // Injective
 	}
 	DefaultEVMChannels = []string{
 		"channel-2", // Injective


### PR DESCRIPTION
### Description

This PR adds functionality to retain claims records instead of deleting them once the last action is claimed. I also added the `DefaultEVMChannels` to the `DefaultAuthorizedChannels` as I understand that the requirement for an EVM chain to claim records is that it also has to be an authorized chain. 