### PR TITLE
audit(erc20): state machine audit

### DIFF
--- a/x/erc20/keeper/evm.go
+++ b/x/erc20/keeper/evm.go
@@ -19,14 +19,17 @@ import (
 )
 
 // QueryERC20 returns the data of a deployed ERC20 contract
-func (k Keeper) QueryERC20(ctx sdk.Context, contract common.Address) (types.ERC20Data, error) {
+func (k Keeper) QueryERC20(
+	ctx sdk.Context,
+	contract common.Address,
+) (types.ERC20Data, error) {
 	var (
 		nameRes    types.ERC20StringResponse
 		symbolRes  types.ERC20StringResponse
 		decimalRes types.ERC20Uint8Response
 	)
 
-	erc20 := contracts.ERC20BurnableContract.ABI
+	erc20 := contracts.ERC20MinterBurnerDecimalsContract.ABI
 
 	// Name
 	res, err := k.CallEVM(ctx, erc20, types.ModuleAddress, contract, false, "name")
@@ -35,7 +38,9 @@ func (k Keeper) QueryERC20(ctx sdk.Context, contract common.Address) (types.ERC2
 	}
 
 	if err := erc20.UnpackIntoInterface(&nameRes, "name", res.Ret); err != nil {
-		return types.ERC20Data{}, sdkerrors.Wrapf(types.ErrABIUnpack, "failed to unpack name: %s", err.Error())
+		return types.ERC20Data{}, sdkerrors.Wrapf(
+			types.ErrABIUnpack, "failed to unpack name: %s", err.Error(),
+		)
 	}
 
 	// Symbol
@@ -45,7 +50,9 @@ func (k Keeper) QueryERC20(ctx sdk.Context, contract common.Address) (types.ERC2
 	}
 
 	if err := erc20.UnpackIntoInterface(&symbolRes, "symbol", res.Ret); err != nil {
-		return types.ERC20Data{}, sdkerrors.Wrapf(types.ErrABIUnpack, "failed to unpack symbol: %s", err.Error())
+		return types.ERC20Data{}, sdkerrors.Wrapf(
+			types.ErrABIUnpack, "failed to unpack symbol: %s", err.Error(),
+		)
 	}
 
 	// Decimals
@@ -55,7 +62,9 @@ func (k Keeper) QueryERC20(ctx sdk.Context, contract common.Address) (types.ERC2
 	}
 
 	if err := erc20.UnpackIntoInterface(&decimalRes, "decimals", res.Ret); err != nil {
-		return types.ERC20Data{}, sdkerrors.Wrapf(types.ErrABIUnpack, "failed to unpack decimals: %s", err.Error())
+		return types.ERC20Data{}, sdkerrors.Wrapf(
+			types.ErrABIUnpack, "failed to unpack decimals: %s", err.Error(),
+		)
 	}
 
 	return types.NewERC20Data(nameRes.Value, symbolRes.Value, decimalRes.Value), nil

--- a/x/erc20/keeper/evm.go
+++ b/x/erc20/keeper/evm.go
@@ -6,6 +6,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
+	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -17,6 +18,45 @@ import (
 	"github.com/tharsis/evmos/v3/contracts"
 	"github.com/tharsis/evmos/v3/x/erc20/types"
 )
+
+// DeployERC20Contract creates and deploys an ERC20 contract on the EVM with the
+// erc20 module account as owner.
+func (k Keeper) DeployERC20Contract(
+	ctx sdk.Context,
+	coinMetadata banktypes.Metadata,
+) (common.Address, error) {
+	decimals := uint8(0)
+	if len(coinMetadata.DenomUnits) > 0 {
+		decimalsIdx := len(coinMetadata.DenomUnits) - 1
+		decimals = uint8(coinMetadata.DenomUnits[decimalsIdx].Exponent)
+	}
+	ctorArgs, err := contracts.ERC20MinterBurnerDecimalsContract.ABI.Pack(
+		"",
+		coinMetadata.Name,
+		coinMetadata.Symbol,
+		decimals,
+	)
+	if err != nil {
+		return common.Address{}, sdkerrors.Wrapf(types.ErrABIPack, "coin metadata is invalid %s: %s", coinMetadata.Name, err.Error())
+	}
+
+	data := make([]byte, len(contracts.ERC20MinterBurnerDecimalsContract.Bin)+len(ctorArgs))
+	copy(data[:len(contracts.ERC20MinterBurnerDecimalsContract.Bin)], contracts.ERC20MinterBurnerDecimalsContract.Bin)
+	copy(data[len(contracts.ERC20MinterBurnerDecimalsContract.Bin):], ctorArgs)
+
+	nonce, err := k.accountKeeper.GetSequence(ctx, types.ModuleAddress.Bytes())
+	if err != nil {
+		return common.Address{}, err
+	}
+
+	contractAddr := crypto.CreateAddress(types.ModuleAddress, nonce)
+	_, err = k.CallEVMWithData(ctx, types.ModuleAddress, nil, data, true)
+	if err != nil {
+		return common.Address{}, sdkerrors.Wrapf(err, "failed to deploy contract for %s", coinMetadata.Name)
+	}
+
+	return contractAddr, nil
+}
 
 // QueryERC20 returns the data of a deployed ERC20 contract
 func (k Keeper) QueryERC20(

--- a/x/erc20/keeper/evm.go
+++ b/x/erc20/keeper/evm.go
@@ -10,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	ethtypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/tharsis/ethermint/server/config"
 	evmtypes "github.com/tharsis/ethermint/x/evm/types"
 
@@ -166,4 +167,25 @@ func (k Keeper) CallEVMWithData(
 	}
 
 	return res, nil
+}
+
+// monitorApprovalEvent returns an error if the given transactions logs include
+// an unexpected `Approval` event
+func (k Keeper) monitorApprovalEvent(res *evmtypes.MsgEthereumTxResponse) error {
+	if res == nil || len(res.Logs) == 0 {
+		return nil
+	}
+
+	logApprovalSig := []byte("Approval(address,address,uint256)")
+	logApprovalSigHash := crypto.Keccak256Hash(logApprovalSig)
+
+	for _, log := range res.Logs {
+		if log.Topics[0] == logApprovalSigHash.Hex() {
+			return sdkerrors.Wrapf(
+				types.ErrUnexpectedEvent, "unexpected Approval event",
+			)
+		}
+	}
+
+	return nil
 }

--- a/x/erc20/keeper/evm_hooks.go
+++ b/x/erc20/keeper/evm_hooks.go
@@ -43,7 +43,7 @@ func (h Hooks) PostTxProcessing(
 		return nil
 	}
 
-	erc20 := contracts.ERC20BurnableContract.ABI
+	erc20 := contracts.ERC20MinterBurnerDecimalsContract.ABI
 
 	for i, log := range receipt.Logs {
 		if len(log.Topics) < 3 {

--- a/x/erc20/keeper/evm_hooks.go
+++ b/x/erc20/keeper/evm_hooks.go
@@ -15,22 +15,26 @@ import (
 	"github.com/tharsis/evmos/v3/x/erc20/types"
 )
 
+var _ evmtypes.EvmHooks = Hooks{}
+
 // Hooks wrapper struct for erc20 keeper
 type Hooks struct {
 	k Keeper
 }
-
-var _ evmtypes.EvmHooks = Hooks{}
 
 // Return the wrapper struct
 func (k Keeper) Hooks() Hooks {
 	return Hooks{k}
 }
 
-// TODO: Make sure that if ConvertERC20 is called, that the Hook doesn't trigger
-// if it does, delete minting from ConvertErc20
-
-// PostTxProcessing implements EvmHooks.PostTxProcessing
+// PostTxProcessing implements EvmHooks.PostTxProcessing. The EVM hooks allows
+// users to convert ERC20s to Cosmos Coins by sending an Ethereum tx transfer to
+// the module account address. This hook applies to both tokenpairs that have
+// been registered through a native Cosmos coin or an ERC20 token.
+//
+// Note that the PostTxProcessing hook is only called by sending an EVM
+// transaction that triggers `ApplyTransaction`. A cosmos tx with a
+// `ConvertERC20` msg does not trigger the hook as it only calls `ApplyMessage`.
 func (h Hooks) PostTxProcessing(
 	ctx sdk.Context,
 	msg core.Message,
@@ -38,26 +42,27 @@ func (h Hooks) PostTxProcessing(
 ) error {
 	params := h.k.GetParams(ctx)
 	if !params.EnableErc20 || !params.EnableEVMHook {
-		// no error is returned to allow for other post processing txs
-		// to pass
+		// no error is returned to avoid reverting the tx and allow for other post
+		// processing txs to pass and
 		return nil
 	}
 
 	erc20 := contracts.ERC20MinterBurnerDecimalsContract.ABI
 
 	for i, log := range receipt.Logs {
-		if len(log.Topics) < 3 {
+		// Note: the transfer event contains 3 topics
+		if len(log.Topics) != 3 {
 			continue
 		}
 
-		eventID := log.Topics[0] // event ID
-
+		// Check if event is included in ERC20
+		eventID := log.Topics[0]
 		event, err := erc20.EventByID(eventID)
 		if err != nil {
-			// invalid event for ERC20
 			continue
 		}
 
+		// Check if event is a `Transfer` event.
 		if event.Name != types.ERC20EventTransfer {
 			h.k.Logger(ctx).Info("emitted event", "name", event.Name, "signature", event.Sig)
 			continue
@@ -79,13 +84,10 @@ func (h Hooks) PostTxProcessing(
 			continue
 		}
 
-		// check that the contract is a registered token pair
+		// Check that the contract is a registered token pair
 		contractAddr := log.Address
-
 		id := h.k.GetERC20Map(ctx, contractAddr)
-
 		if len(id) == 0 {
-			// no token is registered for the caller contract
 			continue
 		}
 
@@ -94,9 +96,10 @@ func (h Hooks) PostTxProcessing(
 			continue
 		}
 
-		// check that conversion for the pair is enabled
+		// Check that conversion for the pair is enabled
 		if !pair.Enabled {
-			// continue to allow transfers for the ERC20 in case the token pair is disabled
+			// continue to allow transfers for the ERC20 in case the token pair is
+			// disabled
 			h.k.Logger(ctx).Debug(
 				"ERC20 token -> Cosmos coin conversion is disabled for pair",
 				"coin", pair.Denom, "contract", pair.Erc20Address,
@@ -104,19 +107,20 @@ func (h Hooks) PostTxProcessing(
 			continue
 		}
 
-		// ignore as the burning always transfers to the zero address
+		// Check if tokens are sent to module address
 		to := common.BytesToAddress(log.Topics[2].Bytes())
 		if !bytes.Equal(to.Bytes(), types.ModuleAddress.Bytes()) {
 			continue
 		}
 
-		// check that the event is Burn from the ERC20Burnable interface
-		// NOTE: assume that if they are burning the token that has been registered as a pair, they want to mint a Cosmos coin
-
 		// create the corresponding sdk.Coin that is paired with ERC20
 		coins := sdk.Coins{{Denom: pair.Denom, Amount: sdk.NewIntFromBigInt(tokens)}}
 
-		// Mint the coin only if ERC20 is external
+		// Perform token conversion.
+		// Assume the sender of a registered token wants to mint a Cosmos coin. If
+		// token pair has been registered with:
+		//  - coin -> burn tokens and transfer escrowed coins on module to sender
+		//  - token -> escrow tokens on module account and mint & transfer coins to sender
 		switch pair.ContractOwner {
 		case types.OWNER_MODULE:
 			_, err = h.k.CallEVM(ctx, erc20, types.ModuleAddress, contractAddr, true, "burn", tokens)

--- a/x/erc20/keeper/mint.go
+++ b/x/erc20/keeper/mint.go
@@ -20,33 +20,46 @@ func (k Keeper) MintingEnabled(
 ) (types.TokenPair, error) {
 	params := k.GetParams(ctx)
 	if !params.EnableErc20 {
-		return types.TokenPair{}, sdkerrors.Wrap(types.ErrERC20Disabled, "module is currently disabled by governance")
+		return types.TokenPair{}, sdkerrors.Wrap(
+			types.ErrERC20Disabled, "module is currently disabled by governance",
+		)
 	}
 
 	id := k.GetTokenPairID(ctx, token)
 	if len(id) == 0 {
-		return types.TokenPair{}, sdkerrors.Wrapf(types.ErrTokenPairNotFound, "token '%s' not registered by id", token)
+		return types.TokenPair{}, sdkerrors.Wrapf(
+			types.ErrTokenPairNotFound, "token '%s' not registered by id", token,
+		)
 	}
 
 	pair, found := k.GetTokenPair(ctx, id)
 	if !found {
-		return types.TokenPair{}, sdkerrors.Wrapf(types.ErrTokenPairNotFound, "token '%s' not registered", token)
+		return types.TokenPair{}, sdkerrors.Wrapf(
+			types.ErrTokenPairNotFound, "token '%s' not registered", token,
+		)
 	}
 
 	if !pair.Enabled {
-		return types.TokenPair{}, sdkerrors.Wrapf(types.ErrERC20Disabled, "minting token '%s' is not enabled by governance", token)
+		return types.TokenPair{}, sdkerrors.Wrapf(
+			types.ErrERC20Disabled, "minting token '%s' is not enabled by governance", token,
+		)
 	}
 
 	if k.bankKeeper.BlockedAddr(receiver.Bytes()) {
-		return types.TokenPair{}, sdkerrors.Wrapf(sdkerrors.ErrUnauthorized, "%s is not allowed to receive transactions", receiver)
+		return types.TokenPair{}, sdkerrors.Wrapf(
+			sdkerrors.ErrUnauthorized, "%s is not allowed to receive transactions", receiver,
+		)
 	}
 
 	// NOTE: ignore amount as only denom is checked on IsSendEnabledCoin
 	coin := sdk.Coin{Denom: pair.Denom}
 
-	// check if minting to a recipient address other than the sender is enabled for for the given coin denom
+	// check if minting to a recipient address other than the sender is enabled
+	// for for the given coin denom
 	if !sender.Equals(receiver) && !k.bankKeeper.IsSendEnabledCoin(ctx, coin) {
-		return types.TokenPair{}, sdkerrors.Wrapf(banktypes.ErrSendDisabled, "minting '%s' coins to an external address is currently disabled", token)
+		return types.TokenPair{}, sdkerrors.Wrapf(
+			banktypes.ErrSendDisabled, "minting '%s' coins to an external address is currently disabled", token,
+		)
 	}
 
 	return pair, nil

--- a/x/erc20/keeper/proposals.go
+++ b/x/erc20/keeper/proposals.go
@@ -7,45 +7,56 @@ import (
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	banktypes "github.com/cosmos/cosmos-sdk/x/bank/types"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
 
-	"github.com/tharsis/evmos/v3/contracts"
 	"github.com/tharsis/evmos/v3/x/erc20/types"
 )
 
-// RegisterCoin deploys an erc20 contract and creates the token pair for the existing cosmos coin
-func (k Keeper) RegisterCoin(ctx sdk.Context, coinMetadata banktypes.Metadata) (*types.TokenPair, error) {
-	// check if the conversion is globally enabled
+// RegisterCoin deploys an erc20 contract and creates the token pair for the
+// existing cosmos coin
+func (k Keeper) RegisterCoin(
+	ctx sdk.Context,
+	coinMetadata banktypes.Metadata,
+) (*types.TokenPair, error) {
+	// Check if the conversion is globally enabled
 	params := k.GetParams(ctx)
 	if !params.EnableErc20 {
-		return nil, sdkerrors.Wrap(types.ErrERC20Disabled, "registration is currently disabled by governance")
+		return nil, sdkerrors.Wrap(
+			types.ErrERC20Disabled, "registration is currently disabled by governance",
+		)
 	}
 
-	// prohibit denominations that contain the evm denom
+	// Prohibit denominations that contain the evm denom
 	if strings.Contains(coinMetadata.Base, "evm") {
-		return nil, sdkerrors.Wrapf(types.ErrEVMDenom, "cannot register the EVM denomination %s", coinMetadata.Base)
+		return nil, sdkerrors.Wrapf(
+			types.ErrEVMDenom, "cannot register the EVM denomination %s", coinMetadata.Base,
+		)
 	}
 
-	// check if the denomination already registered
+	// Check if denomination is already registered
 	if k.IsDenomRegistered(ctx, coinMetadata.Name) {
-		return nil, sdkerrors.Wrapf(types.ErrTokenPairAlreadyExists, "coin denomination already registered: %s", coinMetadata.Name)
+		return nil, sdkerrors.Wrapf(
+			types.ErrTokenPairAlreadyExists, "coin denomination already registered: %s", coinMetadata.Name,
+		)
 	}
 
-	// check if the coin exists by ensuring the supply is set
+	// Check if the coin exists by ensuring the supply is set
 	if !k.bankKeeper.HasSupply(ctx, coinMetadata.Base) {
 		return nil, sdkerrors.Wrapf(
-			sdkerrors.ErrInvalidCoins,
-			"base denomination '%s' cannot have a supply of 0", coinMetadata.Base,
+			sdkerrors.ErrInvalidCoins, "base denomination '%s' cannot have a supply of 0", coinMetadata.Base,
 		)
 	}
 
 	if err := k.verifyMetadata(ctx, coinMetadata); err != nil {
-		return nil, sdkerrors.Wrapf(types.ErrInternalTokenPair, "coin metadata is invalid %s", coinMetadata.Name)
+		return nil, sdkerrors.Wrapf(
+			types.ErrInternalTokenPair, "coin metadata is invalid %s", coinMetadata.Name,
+		)
 	}
 
 	addr, err := k.DeployERC20Contract(ctx, coinMetadata)
 	if err != nil {
-		return nil, sdkerrors.Wrap(err, "failed to create wrapped coin denom metadata for ERC20")
+		return nil, sdkerrors.Wrap(
+			err, "failed to create wrapped coin denom metadata for ERC20",
+		)
 	}
 
 	pair := types.NewTokenPair(addr, coinMetadata.Base, true, types.OWNER_MODULE)
@@ -56,70 +67,32 @@ func (k Keeper) RegisterCoin(ctx sdk.Context, coinMetadata banktypes.Metadata) (
 	return &pair, nil
 }
 
-// verify if the metadata matches the existing one, if not it sets it to the store
-func (k Keeper) verifyMetadata(ctx sdk.Context, coinMetadata banktypes.Metadata) error {
-	meta, found := k.bankKeeper.GetDenomMetaData(ctx, coinMetadata.Base)
-	if !found {
-		k.bankKeeper.SetDenomMetaData(ctx, coinMetadata)
-		return nil
-	}
-	// If it already existed, Check that is equal to what is stored
-	return types.EqualMetadata(meta, coinMetadata)
-}
-
-// DeployERC20Contract creates and deploys an ERC20 contract on the EVM with the
-// erc20 module account as owner.
-func (k Keeper) DeployERC20Contract(
+// RegisterERC20 creates a Cosmos coin and registers the token pair between the
+// coin and the ERC20
+func (k Keeper) RegisterERC20(
 	ctx sdk.Context,
-	coinMetadata banktypes.Metadata,
-) (common.Address, error) {
-	decimals := uint8(0)
-	if len(coinMetadata.DenomUnits) > 0 {
-		decimalsIdx := len(coinMetadata.DenomUnits) - 1
-		decimals = uint8(coinMetadata.DenomUnits[decimalsIdx].Exponent)
-	}
-	ctorArgs, err := contracts.ERC20MinterBurnerDecimalsContract.ABI.Pack(
-		"",
-		coinMetadata.Name,
-		coinMetadata.Symbol,
-		decimals,
-	)
-	if err != nil {
-		return common.Address{}, sdkerrors.Wrapf(types.ErrABIPack, "coin metadata is invalid %s: %s", coinMetadata.Name, err.Error())
-	}
-
-	data := make([]byte, len(contracts.ERC20MinterBurnerDecimalsContract.Bin)+len(ctorArgs))
-	copy(data[:len(contracts.ERC20MinterBurnerDecimalsContract.Bin)], contracts.ERC20MinterBurnerDecimalsContract.Bin)
-	copy(data[len(contracts.ERC20MinterBurnerDecimalsContract.Bin):], ctorArgs)
-
-	nonce, err := k.accountKeeper.GetSequence(ctx, types.ModuleAddress.Bytes())
-	if err != nil {
-		return common.Address{}, err
-	}
-
-	contractAddr := crypto.CreateAddress(types.ModuleAddress, nonce)
-	_, err = k.CallEVMWithData(ctx, types.ModuleAddress, nil, data, true)
-	if err != nil {
-		return common.Address{}, sdkerrors.Wrapf(err, "failed to deploy contract for %s", coinMetadata.Name)
-	}
-
-	return contractAddr, nil
-}
-
-// RegisterERC20 creates a cosmos coin and registers the token pair between the coin and the ERC20
-func (k Keeper) RegisterERC20(ctx sdk.Context, contract common.Address) (*types.TokenPair, error) {
+	contract common.Address,
+) (*types.TokenPair, error) {
+	// Check if the conversion is globally enabled
 	params := k.GetParams(ctx)
 	if !params.EnableErc20 {
-		return nil, sdkerrors.Wrap(types.ErrERC20Disabled, "registration is currently disabled by governance")
+		return nil, sdkerrors.Wrap(
+			types.ErrERC20Disabled, "registration is currently disabled by governance",
+		)
 	}
 
+	// Check if ERC20 is already registered
 	if k.IsERC20Registered(ctx, contract) {
-		return nil, sdkerrors.Wrapf(types.ErrTokenPairAlreadyExists, "token ERC20 contract already registered: %s", contract.String())
+		return nil, sdkerrors.Wrapf(
+			types.ErrTokenPairAlreadyExists, "token ERC20 contract already registered: %s", contract.String(),
+		)
 	}
 
 	metadata, err := k.CreateCoinMetadata(ctx, contract)
 	if err != nil {
-		return nil, sdkerrors.Wrap(err, "failed to create wrapped coin denom metadata for ERC20")
+		return nil, sdkerrors.Wrap(
+			err, "failed to create wrapped coin denom metadata for ERC20",
+		)
 	}
 
 	pair := types.NewTokenPair(contract, metadata.Name, true, types.OWNER_EXTERNAL)
@@ -129,8 +102,12 @@ func (k Keeper) RegisterERC20(ctx sdk.Context, contract common.Address) (*types.
 	return &pair, nil
 }
 
-// CreateCoinMetadata generates the metadata to represent the ERC20 token on evmos.
-func (k Keeper) CreateCoinMetadata(ctx sdk.Context, contract common.Address) (*banktypes.Metadata, error) {
+// CreateCoinMetadata generates the metadata to represent the ERC20 token on
+// evmos.
+func (k Keeper) CreateCoinMetadata(
+	ctx sdk.Context,
+	contract common.Address,
+) (*banktypes.Metadata, error) {
 	strContract := contract.String()
 
 	erc20Data, err := k.QueryERC20(ctx, contract)
@@ -138,14 +115,18 @@ func (k Keeper) CreateCoinMetadata(ctx sdk.Context, contract common.Address) (*b
 		return nil, err
 	}
 
+	// Check if metadata already exists
 	_, found := k.bankKeeper.GetDenomMetaData(ctx, types.CreateDenom(strContract))
 	if found {
-		// metadata already exists; exit
-		return nil, sdkerrors.Wrap(types.ErrInternalTokenPair, "denom metadata already registered")
+		return nil, sdkerrors.Wrap(
+			types.ErrInternalTokenPair, "denom metadata already registered",
+		)
 	}
 
 	if k.IsDenomRegistered(ctx, types.CreateDenom(strContract)) {
-		return nil, sdkerrors.Wrapf(types.ErrInternalTokenPair, "coin denomination already registered: %s", erc20Data.Name)
+		return nil, sdkerrors.Wrapf(
+			types.ErrInternalTokenPair, "coin denomination already registered: %s", erc20Data.Name,
+		)
 	}
 
 	// base denomination
@@ -183,7 +164,9 @@ func (k Keeper) CreateCoinMetadata(ctx sdk.Context, contract common.Address) (*b
 	}
 
 	if err := metadata.Validate(); err != nil {
-		return nil, sdkerrors.Wrapf(err, "ERC20 token data is invalid for contract %s", strContract)
+		return nil, sdkerrors.Wrapf(
+			err, "ERC20 token data is invalid for contract %s", strContract,
+		)
 	}
 
 	k.bankKeeper.SetDenomMetaData(ctx, metadata)
@@ -192,19 +175,42 @@ func (k Keeper) CreateCoinMetadata(ctx sdk.Context, contract common.Address) (*b
 }
 
 // ToggleConversion toggles conversion for a given token pair
-func (k Keeper) ToggleConversion(ctx sdk.Context, token string) (types.TokenPair, error) {
+func (k Keeper) ToggleConversion(
+	ctx sdk.Context,
+	token string,
+) (types.TokenPair, error) {
 	id := k.GetTokenPairID(ctx, token)
 	if len(id) == 0 {
-		return types.TokenPair{}, sdkerrors.Wrapf(types.ErrTokenPairNotFound, "token '%s' not registered by id", token)
+		return types.TokenPair{}, sdkerrors.Wrapf(
+			types.ErrTokenPairNotFound, "token '%s' not registered by id", token,
+		)
 	}
 
 	pair, found := k.GetTokenPair(ctx, id)
 	if !found {
-		return types.TokenPair{}, sdkerrors.Wrapf(types.ErrTokenPairNotFound, "token '%s' not registered", token)
+		return types.TokenPair{}, sdkerrors.Wrapf(
+			types.ErrTokenPairNotFound, "token '%s' not registered", token,
+		)
 	}
 
 	pair.Enabled = !pair.Enabled
 
 	k.SetTokenPair(ctx, pair)
 	return pair, nil
+}
+
+// verifyMetadata verifies if the metadata matches the existing one, if not it
+// sets it to the store
+func (k Keeper) verifyMetadata(
+	ctx sdk.Context,
+	coinMetadata banktypes.Metadata,
+) error {
+	meta, found := k.bankKeeper.GetDenomMetaData(ctx, coinMetadata.Base)
+	if !found {
+		k.bankKeeper.SetDenomMetaData(ctx, coinMetadata)
+		return nil
+	}
+
+	// If it already existed, Check that is equal to what is stored
+	return types.EqualMetadata(meta, coinMetadata)
 }

--- a/x/erc20/spec/03_state_transitions.md
+++ b/x/erc20/spec/03_state_transitions.md
@@ -20,7 +20,7 @@ A user registers a native Cosmos Coin. Once the proposal passes (i.e is Approval
 
 ### 2. Register ERC20
 
-A user registers a ERC20 token contract that is already deployed on the EVM module. Once the proposal passes (i.e is Approvald by governance), the ERC20 module creates an Cosmos coin representation of the ERC20 token.
+A user registers a ERC20 token contract that is already deployed on the EVM module. Once the proposal passes (i.e is approved by governance), the ERC20 module creates a Cosmos coin representation of the ERC20 token.
 
 1. User submits a `RegisterERC20Proposal`
 2. Validators of the EVMOS chain vote on the proposal using `MsgVote` and proposal passes

--- a/x/erc20/spec/03_state_transitions.md
+++ b/x/erc20/spec/03_state_transitions.md
@@ -58,7 +58,7 @@ Conversion of a registered `TokenPair` can be done via:
 2. Check if conversion is allowed for the pair, sender and recipient
     - global parameter is enabled
     - token pair is enabled
-    - sender tokens are not vesting
+    - sender tokens are not vesting (checked in the bank module)
     - recipient address is not blocklisted
 3. If Coin is a native Cosmos Coin and Token Owner is `ModuleAccount`
     1. Escrow Cosmos coin by sending them to the erc20 module account

--- a/x/erc20/spec/03_state_transitions.md
+++ b/x/erc20/spec/03_state_transitions.md
@@ -10,7 +10,7 @@ The erc20 modules allows for two types of registration state transitions. Depend
 
 ### 1. Register Coin
 
-A user registers a native Cosmos Coin. Once the proposal passes (i.e is approved by governance), the ERC20 module uses a factory pattern to deploy an ERC20 token contract representation of the Cosmos Coin.
+A user registers a native Cosmos Coin. Once the proposal passes (i.e is Approvald by governance), the ERC20 module uses a factory pattern to deploy an ERC20 token contract representation of the Cosmos Coin.
 
 1. User submits a `RegisterCoinProposal`
 2. Validators of the Evmos Hub vote on the proposal using `MsgVote` and proposal passes
@@ -20,7 +20,7 @@ A user registers a native Cosmos Coin. Once the proposal passes (i.e is approved
 
 ### 2. Register ERC20
 
-A user registers a ERC20 token contract that is already deployed on the EVM module. Once the proposal passes (i.e is approved by governance), the ERC20 module creates an Cosmos coin representation of the ERC20 token.
+A user registers a ERC20 token contract that is already deployed on the EVM module. Once the proposal passes (i.e is Approvald by governance), the ERC20 module creates an Cosmos coin representation of the ERC20 token.
 
 1. User submits a `RegisterERC20Proposal`
 2. Validators of the EVMOS chain vote on the proposal using `MsgVote` and proposal passes
@@ -59,18 +59,17 @@ Conversion of a registered `TokenPair` can be done via:
     - global parameter is enabled
     - token pair is enabled
     - sender tokens are not vesting
-    - recipient address is not blacklisted
-3. If Coin is a native Cosmos Coin  && Token Owner is `ModuleAccount`
+    - recipient address is not blocklisted
+3. If Coin is a native Cosmos Coin and Token Owner is `ModuleAccount`
     1. Escrow Cosmos coin by sending them to the erc20 module account
-    2. Call `mint()` ERC20 tokens from the `ModuleAccount` address
-    3. Send minted Tokens to recipient address
+    2. Call `mint()` ERC20 tokens from the `ModuleAccount` address and send minted tokens to recipient address
 4. Check if token balance increased by amount
 
 #### 1.2 ERC20 to Coin
 
 1. User submits a `ConvertERC20` Tx
 2. Check if conversion is allowed for the pair, sender and recipient (see [1.1 Coin to ERC20](#11-coin-to-erc20))
-3. If token is a ERC20 && Token Owner is `ModuleAccount`
+3. If token is a ERC20 and Token Owner is `ModuleAccount`
     1. Call `burnCoins()` on ERC20 to burn ERC20 tokens from the user balance
     2. Send Coins (previously escrowed, see [1.1 Coin to ERC20](#11-coin-to-erc20)) from module to the recipient address.
 4. Check if
@@ -96,22 +95,21 @@ Conversion of a registered `TokenPair` can be done via:
 
 1. User submits a `ConvertERC20` Tx
 2. Check if conversion is allowed for the pair, sender and recipient (See [1.1 Coin to ERC20](#11-coin-to-erc20))
-3. If token is a ERC20 &&  Token Owner is **not** `ModuleAccount`
+3. If token is a ERC20 and Token Owner is **not** `ModuleAccount`
     1. Escrow ERC20 token by sending them to the erc20 module account
-    2. Mint Cosmos coins of the corresponding token pair denomination
-    3. Send coins to the recipient address
+    2. Mint Cosmos coins of the corresponding token pair denomination and send coins to the recipient address
 4. Check if
    - Coin balance increased by amount
    - Token balance decreased by amount
-5. Fail if unexpected `approve` event found in logs to prevent malicious contract behaviour
+5. Fail if unexpected `Approval` event found in logs to prevent malicious contract behaviour
 
 #### 2.2 Coin to ERC20
 
 1. User submits `ConvertCoin` Tx
 2. Check if conversion is allowed for the pair, sender and recipient
-3. If coin is a native Cosmos coin && Token Owner is **not** `ModuleAccount`
+3. If coin is a native Cosmos coin and Token Owner is **not** `ModuleAccount`
     1. Escrow Cosmos Coins by sending them to the erc20 module account
     2. Unlock escrowed ERC20 from the module address by sending it to the recipient
     3. Burn escrowed Cosmos coins
 4. Check if token balance increased by amount
-5. Fail if unexpected `approve` event found in logs to prevent malicious contract behaviour
+5. Fail if unexpected `Approval` event found in logs to prevent malicious contract behaviour

--- a/x/erc20/spec/05_hooks.md
+++ b/x/erc20/spec/05_hooks.md
@@ -8,12 +8,12 @@ The erc20 module implements transaction hooks from the EVM in order to trigger t
 
 ## EVM Hooks
 
-The EVM hooks allows users to convert ERC20s to Cosmos Coins by sending an Ethereum tx transfer to the module account address. This enables native conversion of tokens via Metamask and EVM-enabled wallets.
+The EVM hooks allows users to convert ERC20s to Cosmos Coins by sending an Ethereum tx transfer to the module account address. This enables native conversion of tokens via Metamask and EVM-enabled wallets for both token pairs that have been registered through a native Cosmos coin or an ERC20 token. Note that additional coin/token balance checks for sender and receiver to prevent malicious contract behaviour (as performed in the [`ConvertERC20` msg](03_state_transitions.md#21-erc20-to-coin)) cannot be done here, as the balance prior to the transaction is not avaialble in the hook.
 
 ### Registered Coin: ERC20 to Coin
 
 1. User transfers ERC20 tokens to the `ModuleAccount` address to escrow them
-2. Check if the ERC20 Token that was transferred from the sender is a native ERC20 or a native Cosmos Coin by looking at the ethereum Logs
+2. Check if the ERC20 Token that was transferred from the sender is a native ERC20 or a native Cosmos Coin by looking at the [Ethereum event logs](https://medium.com/mycrypto/understanding-event-logs-on-the-ethereum-blockchain-f4ae7ba50378#:~:text=A%20log%20record%20can%20be,or%20a%20change%20of%20ownership.&text=Each%20log%20record%20consists%20of,going%20on%20in%20an%20event)
 3. If the token contract address corresponds to the ERC20 representation of a native Cosmos Coin
     1. Call `burn()` ERC20 method from the  `ModuleAccount`. Note that this is the same as 1.2, but since the tokens are already on the ModuleAccount balance, we burn the tokens from the module address instead of calling `burnFrom()`. Also note that we don't need to mint because [1.1 coin to erc20](03_state_transitions.md#11-coin-to-erc20) escrows the coin
     2. Transfer Cosmos Coin to the bech32 account address of the sender hex address


### PR DESCRIPTION
## Description

This PR adds minor improvements from performing a state machine audit on the x/erc20 module:

- improved comments
- moved evm relevant helper methods to `evm.go`
- updated specs

## Open questions: 

- are the migrations necessary?

## Future improvements

- Toggle token pair: Should we revert the token transfer through the hook if a token pair is disabled?
-  Add tests make sure that if ConvertERC20 is called, that the Hook doesn't trigger 



