### PR TITLE
impr(erc20): fix cli register ibc coin template

### DIFF
--- a/x/erc20/client/cli/tx.go
+++ b/x/erc20/client/cli/tx.go
@@ -157,14 +157,14 @@ Where metadata.json contains (example):
 				"aliases": ["ibcuosmo"]
 		},
 		{
-				"denom": "ibcOSMO",
+				"denom": "ibcOSMO-0",
 				"exponent": 6
 		}
 	],
 	"base": "ibc/<HASH>",
-	"display": "ibcOSMO",
+	"display": "ibcOSMO-0",
 	"name": "Osmo channel-0",
-	"symbol": "ibcOSMO"
+	"symbol": "ibcOSMO-0"
 }`, version.AppName,
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/erc20/client/cli/tx.go
+++ b/x/erc20/client/cli/tx.go
@@ -162,8 +162,8 @@ Where metadata.json contains (example):
 		}
 	],
 	"base": "ibc/<HASH>",
-	"display": "ibcOSMOS",
-	"name": "IBC Osmo",
+	"display": "ibcOSMO",
+	"name": "Osmo channel-0",
 	"symbol": "ibcOSMO"
 }`, version.AppName,
 		),

--- a/x/erc20/keeper/mint.go
+++ b/x/erc20/keeper/mint.go
@@ -41,7 +41,7 @@ func (k Keeper) MintingEnabled(
 
 	if !pair.Enabled {
 		return types.TokenPair{}, sdkerrors.Wrapf(
-			types.ErrERC20Disabled, "minting token '%s' is not enabled by governance", token,
+			types.ErrERC20TokenPairDisabled, "minting token '%s' is not enabled by governance", token,
 		)
 	}
 

--- a/x/erc20/types/errors.go
+++ b/x/erc20/types/errors.go
@@ -17,4 +17,5 @@ var (
 	ErrABIUnpack              = sdkerrors.Register(ModuleName, 10, "contract ABI unpack failed")
 	ErrEVMDenom               = sdkerrors.Register(ModuleName, 11, "EVM denomination registration")
 	ErrEVMCall                = sdkerrors.Register(ModuleName, 12, "EVM call unexpected error")
+	ErrERC20TokenPairDisabled = sdkerrors.Register(ModuleName, 13, "erc20 token pair is disabled")
 )


### PR DESCRIPTION
## Description

I noticed that the template for registering a coin is not accurate and doesn't pass stateless validations.