### PR TITLE
changing Cosmos Coin registration naming

### DIFF
--- a/x/erc20/spec/01_concepts.md
+++ b/x/erc20/spec/01_concepts.md
@@ -40,10 +40,13 @@ The native Cosmos Coin contains a more extensive metadata than the ERC20 and inc
 
 #### IBC voucher Metadata to ERC20 details
 
-IBC vouchers should comply to the following standard:
+IBC vouchers should comply to the following standard.
 
-- **Name**: `{NAME} channel-{channel}`
-- **Symbol**:  `ibc{NAME}-{channel}`
+- **Name**: `{NAME}` 
+- **Symbol**:  `{NAME}` or `{NAME}-{channel-number}` 
+
+Note: We shouldn't specify a channel number to the symbol `{NAME}` on the first coin registration. E.g. whatever is picked as the canonical channel should be symbol `{NAME}` and if a secondary representation of that IBC token is registered in the evm then a suffix to the symbol `{NAME}-{channel-number}` should be added. 
+
 - **Decimals**:  derived from bank `Metadata`
 
 #### ERC20 details to Coin Metadata


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰    
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## x/erc20 name convention: 

We shouldn't specify a channel number to the symbol {NAME} on the first coin registration. E.g. whatever is picked as the canonical channel should be symbol {NAME} and if a secondary representation of that IBC token is registered in the evm then a suffix to the symbol {NAME}-{channel-number} should be added.

PR according to https://commonwealth.im/evmos/discussion/4969-this-proposal-creates-and-registers-an-erc20-representation-for-osmosis?comment=21136


