### PR TITLE
fix: typo in x/claims REST endpoint docs

### DIFF
--- a/x/claims/spec/07_clients.md
+++ b/x/claims/spec/07_clients.md
@@ -58,5 +58,5 @@ evmosd query claims params [flags]
 | `gRPC` | `evmos.claims.v1.Query/Params`             | Gets claims params                               |
 | `GET`  | `/evmos/claims/v1/total_unclaimed`         | Gets the total unclaimed tokens from the airdrop |
 | `GET`  | `/evmos/claims/v1/claims_records`          | Gets all registered claims records               |
-| `GET`  | `/evmos/claims/v1/claims_record/{address}` | Gets a claims record for a given user            |
+| `GET`  | `/evmos/claims/v1/claims_records/{address}` | Gets a claims record for a given user            |
 | `GET`  | `/evmos/claims/v1/params`                  | Gets claims params                               |


### PR DESCRIPTION
## Description

The x/claims REST endpoint shows /evmos/claims/v1/claims_record/{address}, but it should be claims_records as written in https://github.com/tharsis/evmos/blob/main/proto/evmos/claims/v1/query.proto#L29

Closes: #621 

______

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/tharsis/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/tharsis/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items.

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
