### PR TITLE
Changed return for cli query clientCt…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (fees) [\#612](https://github.com/tharsis/evmos/pull/612) Fix fees registration cli command and description
 - (inflation) [\#554](https://github.com/tharsis/evmos/pull/554) Changing erroneous epoch skips to `daily` instead of `weekly`
 - (claims) [\#626](https://github.com/tharsis/evmos/pull/626) fix durations denominated in `nanoseconds`
+- (claims) [\#629](https://github.com/tharsis/evmos/pull/629) fix epochs durations denominated in `nanoseconds`
 
 ### State Machine Breaking
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,7 +42,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (fees) [\#612](https://github.com/tharsis/evmos/pull/612) Fix fees registration cli command and description
 - (inflation) [\#554](https://github.com/tharsis/evmos/pull/554) Changing erroneous epoch skips to `daily` instead of `weekly`
 - (claims) [\#626](https://github.com/tharsis/evmos/pull/626) fix durations denominated in `nanoseconds`
-- (claims) [\#629](https://github.com/tharsis/evmos/pull/629) fix epochs durations denominated in `nanoseconds`
+- (epochs) [\#629](https://github.com/tharsis/evmos/pull/629) fix epochs durations denominated in `nanoseconds`
 
 ### State Machine Breaking
 

--- a/x/epochs/client/cli/query.go
+++ b/x/epochs/client/cli/query.go
@@ -63,7 +63,8 @@ func GetCmdEpochsInfos() *cobra.Command {
 				return err
 			}
 
-			return clientCtx.PrintProto(res)
+			// return clientCtx.PrintProto(res)
+			return clientCtx.PrintObjectLegacy(res)
 		},
 	}
 


### PR DESCRIPTION
Changed return for query epoch-infos which uses the method clientCtx.PrintProto(&res.Params) to clientCtx.PrintObjectLegacy(&res.Params) emulating the governance module to return the time in nanosecond(int64) string format.

For example:
`evmosd query epochs epoch-infos --node=http://localhost:26657/ --chain-id=evmos_9000-4`
would have produced the following response with duration in seconds:

```
epochs:
- current_epoch: "1"
  current_epoch_start_height: "1"
  current_epoch_start_time: "2022-05-27T15:30:52.675900Z"
  duration: 86400s
  epoch_counting_started: true
  identifier: day
  start_time: "2022-05-27T15:30:52.675900Z"
- current_epoch: "1"
  current_epoch_start_height: "1"
  current_epoch_start_time: "2022-05-27T15:30:52.675900Z"
  duration: 604800s
  epoch_counting_started: true
  identifier: week
  start_time: "2022-05-27T15:30:52.675900Z"
pagination:
  next_key: null
  total: "2"
```
  
  **With this update it now returns the following response with duration in nanoseconds:** 
  
 
  ```
epochs:
- current_epoch: "1"
  current_epoch_start_height: "1"
  current_epoch_start_time: "2022-05-27T20:36:06.837848Z"
  duration: "86400000000000"
  epoch_counting_started: true
  identifier: day
  start_time: "2022-05-27T20:36:06.837848Z"
- current_epoch: "1"
  current_epoch_start_height: "1"
  current_epoch_start_time: "2022-05-27T20:36:06.837848Z"
  duration: "604800000000000"
  epoch_counting_started: true
  identifier: week
  start_time: "2022-05-27T20:36:06.837848Z"
pagination:
  total: "2"
```
  
  

