### PR TITLE
impr(erc20): remove enforcing ibc and channel names during `RegisterCoin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 - (claims) [\#605](https://github.com/tharsis/evmos/pull/605) Remove `claims-` prefix in CLI query commands.
 - (erc20) [\#592](https://github.com/tharsis/evmos/pull/592) Finish module completeness audit.
 
+### Improvements
+
+- (erc20) [\#642](https://github.com/tharsis/evmos/pull/642) Remove enforcing ibc and channel names during `RegisterCoin`
+
 ## [v4.0.1] - 2022-05-10
 
 ### Bug Fixes

--- a/x/erc20/client/cli/tx.go
+++ b/x/erc20/client/cli/tx.go
@@ -157,14 +157,14 @@ Where metadata.json contains (example):
 				"aliases": ["ibcuosmo"]
 		},
 		{
-				"denom": "ibcOSMO-0",
+				"denom": "OSMO",
 				"exponent": 6
 		}
 	],
 	"base": "ibc/<HASH>",
-	"display": "ibcOSMO-0",
-	"name": "Osmo channel-0",
-	"symbol": "ibcOSMO-0"
+	"display": "OSMO",
+	"name": "Osmo",
+	"symbol": "OSMO"
 }`, version.AppName,
 		),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/x/erc20/types/proposal.go
+++ b/x/erc20/types/proposal.go
@@ -95,14 +95,6 @@ func validateIBCVoucherMetadata(metadata banktypes.Metadata) error {
 		return fmt.Errorf("invalid metadata. %s denomination should be prefixed with the format 'ibc/", metadata.Base)
 	}
 
-	if !strings.Contains(metadata.Name, "channel-") {
-		return fmt.Errorf("invalid metadata (Name) for IBC. %s should include channel", metadata.Name)
-	}
-
-	if !strings.HasPrefix(metadata.Symbol, "ibc") {
-		return fmt.Errorf("invalid metadata (Symbol) for IBC. %s should include \"ibc\" prefix", metadata.Symbol)
-	}
-
 	return nil
 }
 

--- a/x/erc20/types/proposal_test.go
+++ b/x/erc20/types/proposal_test.go
@@ -197,8 +197,8 @@ func (suite *ProposalTestSuite) TestRegisterCoinProposal() {
 	}
 
 	validIBCDenom := "ibc/7F1D3FCF4AE79E1554D670D1AD949A9BA4E4A3C76C63093E17E446A46061A7A2"
-	validIBCSymbol := "ibcATOM-14"
-	validIBCName := "ATOM channel-14"
+	validIBCSymbol := "ATOM"
+	validIBCName := "Atom"
 
 	testCases := []struct {
 		msg         string
@@ -225,8 +225,6 @@ func (suite *ProposalTestSuite) TestRegisterCoinProposal() {
 		// Ibc
 		{msg: "Register token pair - ibc", title: "test", description: "test desc", metadata: createFullMetadata(validIBCDenom, validIBCSymbol, validIBCName), expectPass: true},
 		{msg: "Register token pair - ibc invalid denom", title: "test", description: "test desc", metadata: createFullMetadata("ibc/", validIBCSymbol, validIBCName), expectPass: false},
-		{msg: "Register token pair - ibc invalid symbol", title: "test", description: "test desc", metadata: createFullMetadata(validIBCDenom, "badSymbol", validIBCName), expectPass: false},
-		{msg: "Register token pair - ibc invalid name", title: "test", description: "test desc", metadata: createFullMetadata(validIBCDenom, validIBCSymbol, validIBCDenom), expectPass: false},
 	}
 
 	for i, tc := range testCases {


### PR DESCRIPTION
## Description

This PR removes the `Name` and `Symbol` checks so that devs can specify 
* a `Symbol` like `OSMO` instead of `ibcOSMO-0` and
* a `Name` like `Osmo` instead of `Osmo channel-0`