### PR TITLE
[ENG-404] Remove incorrect vesting command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,7 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (claims) [\#605](https://github.com/tharsis/evmos/pull/605) Remove `claims-` prefix in CLI query commands.
 - (erc20) [\#592](https://github.com/tharsis/evmos/pull/592) Finish module completeness audit.
-- (vesting) [\#643](https://github.com/tharsis/evmos/pull/643) Remove `create-vesting-account` cli command.
+- (vesting) [\#643](https://github.com/tharsis/evmos/pull/643) Remove the `create-vesting-account` CLI command from Cosmos SDK in favor of the clawback vesting accounts.
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 - (claims) [\#605](https://github.com/tharsis/evmos/pull/605) Remove `claims-` prefix in CLI query commands.
 - (erc20) [\#592](https://github.com/tharsis/evmos/pull/592) Finish module completeness audit.
+- (vesting) [\#643](https://github.com/tharsis/evmos/pull/643) Remove `create-vesting-account` cli command.
 
 ### Improvements
 

--- a/x/vesting/client/cli/tx.go
+++ b/x/vesting/client/cli/tx.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	"github.com/cosmos/cosmos-sdk/client/tx"
 	sdk "github.com/cosmos/cosmos-sdk/types"
-	sdkvestcli "github.com/cosmos/cosmos-sdk/x/auth/vesting/client/cli"
 	sdkvesting "github.com/cosmos/cosmos-sdk/x/auth/vesting/types"
 
 	"github.com/tharsis/evmos/v4/x/vesting/types"
@@ -42,7 +41,6 @@ func NewTxCmd() *cobra.Command {
 	}
 
 	txCmd.AddCommand(
-		sdkvestcli.NewMsgCreateVestingAccountCmd(),
 		NewMsgCreateClawbackVestingAccountCmd(),
 		NewMsgClawbackCmd(),
 	)


### PR DESCRIPTION
## Description

`create-vesting-account` cli cmd was incorrectly linked. 

Closes: #XXX

______

**All** items are required. Please add a note to the item if the item is not applicable and
please add links to any relevant follow up issues.

PR review checkboxes:

I have...

- [ ] added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] included the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] targeted the correct branch (see [PR Targeting](https://github.com/tharsis/evmos/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] provided a link in the PR description to the relevant issue or specification
- [ ] reviewed "Files changed" and left comments if necessary
- [ ] confirmed all required CI checks have passed

Code maintenance:

I have...

- [ ] written unit and integration [tests](https://github.com/tharsis/evmos/blob/main/CONTRIBUTING.md#testing)
- [ ] added relevant [`godoc`](https://go.dev/blog/godoc) and [code comments](https://blog.jbowen.dev/2019/09/the-magic-of-go-comments/).
- [ ] updated relevant documentation (`docs/`) or specification (`x/<module>/spec/`)

______

### Reviewers Checklist

**All** items are required. Please add a note if the item is not applicable and please add your handle next to the items reviewed if you only reviewed selected items.

I have...

- [ ] confirmed the correct [type prefix](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json) in the PR title
- [ ] confirmed all author checklist items have been addressed
- [ ] confirmed that this PR does not change production code
