### PR TITLE
upgrade(app): remove mainnet condition for migrations that should also apply to testnet

### DIFF
--- a/app/upgrades/v5/upgrades.go
+++ b/app/upgrades/v5/upgrades.go
@@ -64,12 +64,10 @@ func CreateUpgradeHandler(
 			bk.SetDenomMetaData(ctx, TestnetDenomMetadata)
 		}
 
-		if types.IsMainnet(ctx.ChainID()) {
-			logger.Debug("swaping claims record actions...")
-			ResolveAirdrop(ctx, ck)
-			logger.Debug("migrating early contributor claim record...")
-			MigrateContributorClaim(ctx, ck)
-		}
+		logger.Debug("swaping claims record actions...")
+		ResolveAirdrop(ctx, ck)
+		logger.Debug("migrating early contributor claim record...")
+		MigrateContributorClaim(ctx, ck)
 
 		// define from versions of the modules that have a new consensus version
 


### PR DESCRIPTION
## Description

We should aim to divert testnet and mainnet versions as little as possible, so that our testnet environment reflects changes on mainnet better. Therefore this PR applies mainnet migrations also to testnet. 

Part of [ENG-398](https://linear.app/evmos/issue/ENG-398/create-upgrade-handler-for-v5-release)